### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/roles/google-tools/tasks/main.yml
+++ b/roles/google-tools/tasks/main.yml
@@ -320,7 +320,7 @@
 
   ## Ensure the target GDC Connectes Software Only version is available
   - name: Test the bmctl version
-    command: gsutil ls gs://anthos-baremetal-release/bmctl/{{ bmctl_version }}/linux-amd64/bmctl
+    command: gcloud storage ls gs://anthos-baremetal-release/bmctl/{{ bmctl_version }}/linux-amd64/bmctl
     register: bmctl_version_check
     ignore_errors: true
     when:
@@ -344,7 +344,7 @@
     - tool-install
     - bmctl-verify
 
-### Find versions with:  gsutil ls -al gs://anthos-baremetal-release/bmctl
+### Find versions with:  gcloud storage ls --all-versions --long gs://anthos-baremetal-release/bmctl
   - name: Install Anthos Bare Metal CLI
     shell: |
       gcloud storage cp gs://anthos-baremetal-release/bmctl/{{ bmctl_version }}/linux-amd64/bmctl {{ tools_base_path }}
@@ -359,7 +359,7 @@
     - initial-install
     - tool-install
 
-### Find versions with:  gsutil ls -al gs://ncg-release/anthos-baremetal
+### Find versions with:  gcloud storage ls --all-versions --long gs://ncg-release/anthos-baremetal
   - name: Install Network Connectivity Gateway CLI
     shell: |
       gcloud storage cp gs://ncg-release/anthos-baremetal/ncgctl-{{ ncgctl_version }}-linux-amd64.tar.gz {{ tools_base_path }}


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
