### PR TITLE
Adding enhanced fs.file based watch and openfile permissions for k8s

### DIFF
--- a/roles/ready-linux/tasks/main.yml
+++ b/roles/ready-linux/tasks/main.yml
@@ -114,6 +114,7 @@
   - update-dependencies
   - ubuntu-setup
   - inotify
+  - update-fswatch
   when:
   - target_os == "ubuntu"
 
@@ -124,6 +125,16 @@
   - update-dependencies
   - ubuntu-setup
   - inotify
+  - update-fswatch
+  when:
+  - target_os == "ubuntu"
+
+## Update file descriptor limits
+- name: "Include tasks to set file limits"
+  import_tasks: set-file-limits.yml
+  tags:
+  - fd-limits
+  - update-fswatch
   when:
   - target_os == "ubuntu"
 

--- a/roles/ready-linux/tasks/set-file-limits.yml
+++ b/roles/ready-linux/tasks/set-file-limits.yml
@@ -12,15 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Setup proxy for docker (if needed)
-  ansible.builtin.file:
-    path: "{{ docker_service_path }}"
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'
-  when:
-  - proxy_has_http_proxy is true or proxy_has_https_proxy is true
+---
+## Update file descriptor limits
+- name: "Copy script to optimize FD limits"
+  template:
+    src: optimize-fd-limits.sh.j2
+    dest: "{{ abm_install_folder }}/optimize-fd-limits.sh"
+    group: "{{ ansible_user }}"
+    owner: "{{ ansible_user }}"
+    mode: "0744"
   tags:
-  - http-proxy
-  - docker-proxy
+  - update-dependencies
+  - ubuntu-setup
+  - fd-limits
+  - update-fswatch
+
+- name: "Run script to optimize FD limits"
+  command: "{{ abm_install_folder }}/optimize-fd-limits.sh"
+  register: fd_optimization
+  tags:
+  - update-dependencies
+  - ubuntu-setup
+  - fd-limits
+  - update-fswatch

--- a/roles/ready-linux/templates/optimize-fd-limits.sh.j2
+++ b/roles/ready-linux/templates/optimize-fd-limits.sh.j2
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LOG_FILE="/var/log/fd_remediation.log"
+LIMIT_VAL={{ fd_limit_val | default(1048576) }}
+SYSCTL_VAL={{ fd_sysctl_val | default(2097152) }}
+
+echo "--- STARTING FD OPTIMIZATION ---" | tee -a $LOG_FILE
+
+# --- CAPTURE BEFORE ---
+echo "[BEFORE] Current ulimit -n: $(ulimit -n)" | tee -a $LOG_FILE
+echo "[BEFORE] Kernel file-max: $(sysctl -n fs.file-max)" | tee -a $LOG_FILE
+echo "[BEFORE] Systemd DefaultLimitNOFILE: $(grep -i "DefaultLimitNOFILE" /etc/systemd/system.conf || echo "Not Set")" | tee -a $LOG_FILE
+
+# --- 1. SYSTEM LIMITS ---
+cat <<EOF > /etc/security/limits.d/99-fd-limits.conf
+* soft nofile $LIMIT_VAL
+* hard nofile $LIMIT_VAL
+root soft nofile $LIMIT_VAL
+root hard nofile $LIMIT_VAL
+EOF
+
+# --- 2. KERNEL SYSCTL ---
+echo "fs.file-max = $SYSCTL_VAL" > /etc/sysctl.d/99-fd-kernel.conf
+sysctl -p /etc/sysctl.d/99-fd-kernel.conf
+
+# --- 3. SYSTEMD CONFIG ---
+# Update both system and user configs
+sed -i "s/^#\?DefaultLimitNOFILE=.*/DefaultLimitNOFILE=$LIMIT_VAL/" /etc/systemd/system.conf
+sed -i "s/^#\?DefaultLimitNOFILE=.*/DefaultLimitNOFILE=$LIMIT_VAL/" /etc/systemd/user.conf
+systemctl daemon-reexec
+
+# --- 4. PAM SESSION (Ensure limits load)
+if ! grep -q "pam_limits.so" /etc/pam.d/common-session; then
+    echo "session required pam_limits.so" >> /etc/pam.d/common-session
+fi
+
+# --- CAPTURE AFTER ---
+echo "[AFTER] Kernel file-max: $(sysctl -n fs.file-max)" | tee -a $LOG_FILE
+echo "[AFTER] Systemd Config: $(grep "DefaultLimitNOFILE" /etc/systemd/system.conf)" | tee -a $LOG_FILE
+echo "Note: Shell 'ulimit -n' updates require a fresh login session or 'exec bash'." | tee -a $LOG_FILE
+
+echo "--- OPTIMIZATION COMPLETE ---" | tee -a $LOG_FILE

--- a/roles/ready-linux/vars/main.yml
+++ b/roles/ready-linux/vars/main.yml
@@ -27,3 +27,7 @@ gcloud_update_log: "/var/log/gcloud-udpate-script.log"
 # Variables for apt update (host OS patching)
 automatic_update_update_time: "02:15" # Every 2:15am -- TODO: Pull this in some other method for updates (like query an agent on the machine)
 automatic_update_upgrade_time: "02:30"
+
+# Variables for file descriptor limits
+fd_limit_val: 1048576
+fd_sysctl_val: 2097152


### PR DESCRIPTION
## Summary
- Adding scripts to install/setup iflenode watching

## Test Plan
- [x] Run with tags in isolation. [[ `--tags fs-filewatch`]]
- [x] Confirm inotify watch settings post reboot.